### PR TITLE
DocC Post Updates

### DIFF
--- a/Content/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation.md
+++ b/Content/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation.md
@@ -5,6 +5,8 @@ description: DocC is Apple’s recommended way to provide documentation for your
 Swift Package Index can generate, host, and update package documentation for any package in the index!
 ---
 
+**UPDATE:** We now support auto-generation of *versioned* documentation, too! [Find out more details here](https://blog.swiftpackageindex.com/posts/versioned-docc-documentation/).
+
 Introduced at WWDC 2021, [DocC](https://developer.apple.com/documentation/docc) is Apple’s recommended way to provide documentation for your packages.
 
 It’s easy to use, and the resulting documentation looks great. It generates documentation either from comments or separate article files written in Markdown that is more suitable for longer-form documentation. You can even use it to create beautiful interactive tutorials with images and step-by-step instructions. DocC generates either an Xcode documentation archive or a set of HTML and CSS files that you can host on a web server.

--- a/Content/posts/versioned-docc-documentation.md
+++ b/Content/posts/versioned-docc-documentation.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-08-04 12:00
+date: 2022-08-05 12:00
 title: Versioned DocC Documentation
 description: We rolled out auto-generating DocC documentation exactly two months ago, and now we’re rolling out phase two. Versioned documentation!
 ---


### PR DESCRIPTION
* Added a link to the versioned post from the DocC launch post. We should continue to highlight that post on the site as it contains the instructions for adding support. We *really* need to document the manifest!
* Moved the date forward one day as it was showing under the episode 8 post.